### PR TITLE
修改配置文件路径

### DIFF
--- a/phinx/src/Phinx/Config.php
+++ b/phinx/src/Phinx/Config.php
@@ -51,7 +51,7 @@ class Config
     public function __construct($configFile)
     {
         // 加载配置
-        $this->values = include APP_PATH . 'config' . EXT;
+        $this->values = include CONF_PATH . 'config' . EXT;
         //加载数据库配置
         $config = include $configFile;
 

--- a/src/command/AbstractCommand.php
+++ b/src/command/AbstractCommand.php
@@ -155,7 +155,7 @@ abstract class AbstractCommand extends Command
         $configFile = $input->getOption('configuration');
 
         if (null === $configFile || false === $configFile) {
-            $configFile = APP_PATH . 'database' . EXT;
+            $configFile = CONF_PATH . 'database' . EXT;
         }
 
         if (!is_file($configFile)) {


### PR DESCRIPTION
改动：配置文件路径由常量  APP_PATH 改为 CONF_PATH
改动原因：如果用户修改了默认配置目录，当执行迁移命令时，会导致一个`InvalidArgumentException`异常
