### PR TITLE
id默认unsigned

### DIFF
--- a/phinx/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/phinx/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -215,6 +215,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $column = new Column();
             $column->setName('id')
                    ->setType('integer')
+                   ->setSigned(isset($options['signed']) ? $options['signed'] : false)
                    ->setIdentity(true);
 
             array_unshift($columns, $column);


### PR DESCRIPTION
老版本的phinx默认ID是signed类型，且无法进一步设置。修改后更改为默认unsigned类型，且可以配置signed为true来重置为signed类型。
` $this->table('admin')->create();  //ID为unsigned类型`
` $this->table('admin',['signed' => 'true'])->create();  //ID为signed类型`