### PR TITLE
fix 取消默认数据库配置

### DIFF
--- a/src/command/Migrate.php
+++ b/src/command/Migrate.php
@@ -34,7 +34,7 @@ abstract class Migrate extends Command
 
         parent::__construct($name);
 
-        $this->addOption('--config', null, InputOption::VALUE_REQUIRED, 'The database config name', 'database');
+        $this->addOption('--config', null, InputOption::VALUE_REQUIRED, 'The database config name', '');
     }
 
     /**


### PR DESCRIPTION
设置默认数据库 ‘database’ 后 TP 5.1.* 出现不兼容情况，无法正常获取数据库配置