### PR TITLE
解决未定义数组'deploy'的问题,数据库配置格式变了.

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -41,7 +41,7 @@ abstract class Command extends \think\console\Command
      */
     protected function getDbConfig(): array
     {
-        $config = $this->app->config->get('database');
+        $config = $this->app->config->get('database.connections.'.Env::get('database.driver', 'mysql'));
 
         if (0 == $config['deploy']) {
             $dbConfig = [


### PR DESCRIPTION
再到当前的thinkphp6-dev,think-migration3下运行命令:

php think migrate:run

会报出 未定义数组索引 deploy,

这是在引入数据库配置文件时,引入database,但实际上配置文件的链接已经改为database.connections.XXX,改完这一行就可以正常执行创建数据库了.