### PR TITLE
修正迁移表中timestamp默认值

### DIFF
--- a/phinx/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/phinx/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -518,8 +518,8 @@ abstract class PdoAdapter implements AdapterInterface
             } else {
                 $table->addColumn('version', 'biginteger')
                       ->addColumn('migration_name', 'string', array('limit' => 100, 'default' => null, 'null' => true))
-                      ->addColumn('start_time', 'timestamp')
-                      ->addColumn('end_time', 'timestamp')
+                      ->addColumn('start_time', 'timestamp', ['default' => null, 'null' => true])
+                      ->addColumn('end_time', 'timestamp', ['default' => null, 'null' => true])
                       ->addColumn('breakpoint', 'boolean', array('default' => false))
                       ->save();
             }


### PR DESCRIPTION
在高版本的mysql和mariadb中报错，经过与新版本phinx的核对，这个位置必须要加一个默认值。测试环境：PHP7.3.7+MariaDB10.3.16