### PR TITLE
修复mapClassNameToFileName中implode的bug

### DIFF
--- a/phinx/src/Phinx/Util/Util.php
+++ b/phinx/src/Phinx/Util/Util.php
@@ -106,7 +106,7 @@ class Util
     {
         $arr = preg_split('/(?=[A-Z])/', $className);
         unset($arr[0]); // remove the first element ('')
-        $fileName = static::getCurrentTimestamp() . '_' . strtolower(implode($arr, '_')) . '.php';
+        $fileName = static::getCurrentTimestamp() . '_' . strtolower(implode('_', $arr)) . '.php';
         return $fileName;
     }
 


### PR DESCRIPTION
`string implode ( string $glue , array $pieces)`
源代码中的参数写反了。
`implode(): Passing glue string after array is deprecated. Swap the parameters`