### PR TITLE
修改implode接口参数顺序

### DIFF
--- a/phinx/src/Phinx/Util/Util.php
+++ b/phinx/src/Phinx/Util/Util.php
@@ -106,7 +106,7 @@ class Util
     {
         $arr = preg_split('/(?=[A-Z])/', $className);
         unset($arr[0]); // remove the first element ('')
-        $fileName = static::getCurrentTimestamp() . '_' . strtolower(implode($arr, '_')) . '.php';
+        $fileName = static::getCurrentTimestamp() . '_' . strtolower(implode('_', $arr)) . '.php';
         return $fileName;
     }
 


### PR DESCRIPTION
PHP7.4之前，implode支持两种参数顺序：
implode(array $pieces, string $glue);
和
implode(string $glue, array $pieces);

但是PHP7.4开始，废弃了第一种参数顺序
所以在PHP7.4环境下执行php think migrate:create OneMigrate，会出现如下异常：
[InvalidArgumentException]                                               
  The migration class name "OneMigrate" is invalid. Please use CamelCase format.
