### PR TITLE
fix: 修复Util类中implode函数调用报错的问题

### DIFF
--- a/phinx/src/Phinx/Util/Util.php
+++ b/phinx/src/Phinx/Util/Util.php
@@ -106,7 +106,7 @@ class Util
     {
         $arr = preg_split('/(?=[A-Z])/', $className);
         unset($arr[0]); // remove the first element ('')
-        $fileName = static::getCurrentTimestamp() . '_' . strtolower(implode($arr, '_')) . '.php';
+        $fileName = static::getCurrentTimestamp() . '_' . strtolower(implode('_', $arr)) . '.php';
         return $fileName;
     }
 


### PR DESCRIPTION
目前直接影响`php think migrate:create`命令，希望能尽快merge