### PR TITLE
修复在php7.4环境下的报错

### DIFF
--- a/src/command/migrate/Status.php
+++ b/src/command/migrate/Status.php
@@ -74,6 +74,8 @@ EOT
                     $status = '     <info>up</info> ';
                 } else {
                     $status = '   <error>down</error> ';
+                    $version = [];
+                    $version['start_time'] = $version['end_time'] = $version['breakpoint'] = '';
                 }
                 $maxNameLength = max($maxNameLength, strlen($migration->getName()));
 


### PR DESCRIPTION
原来的那种写法（$version['start_time']）在php7.4下执行 php think migrate:status 会报错如下图，
我简单修复了一下，
第一次提pr希望能够被通过~
![image](https://user-images.githubusercontent.com/16048349/132505449-b494b0db-e90c-4e62-ad8d-73740e11ef7e.png)
