### PR TITLE
fix: Creation of dynamic property think\...\Run::$adapter in PHP8.2

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -15,7 +15,8 @@ use Phinx\Db\Adapter\AdapterFactory;
 
 abstract class Command extends \think\console\Command
 {
-
+    protected $adapter;
+    
     public function getAdapter()
     {
         if (isset($this->adapter)) {


### PR DESCRIPTION
think\exception\ErrorException: Creation of dynamic property think\migration\command\migrate\Run::$adapter is deprecated