### PR TITLE
去除 Sqlite 默认后缀 .sqlite ，与 ThinkPHP 保持同步。

### DIFF
--- a/phinx/Db/Adapter/SQLiteAdapter.php
+++ b/phinx/Db/Adapter/SQLiteAdapter.php
@@ -122,7 +122,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @var string
      */
-    protected $suffix = '.sqlite3';
+    protected $suffix = '';
 
     /**
      * Indicates whether the database library version is at least the specified version


### PR DESCRIPTION
更多详情请查看：#100   ISSUES

由于当前最新版本的 ThinkPHP 并未传 suffix 参数过来，与 ThinkPHP 的 Sqlite 后缀与此不符合。

导致 ThinkPHP 无法读取 Sqlite 数据库