### PR TITLE
修复 setLimit(): Argument #1 ($limit) must be of type ?int 错误

### DIFF
--- a/phinx/Db/Table/Column.php
+++ b/phinx/Db/Table/Column.php
@@ -770,8 +770,8 @@ class Column
      * Utility method that maps an array of column options to this objects methods.
      *
      * @param array<string, mixed> $options Options
-     * @throws \RuntimeException
      * @return $this
+     * @throws \RuntimeException
      */
     public function setOptions(array $options)
     {
@@ -793,6 +793,13 @@ class Column
             }
 
             $method = 'set' . ucfirst($option);
+
+            if (ucfirst($option) == 'Limit') {
+                if ($value) {
+                    $value = (int)$value;
+                }
+            }
+
             $this->$method($value);
         }
 

--- a/phinx/Db/Table/Column.php
+++ b/phinx/Db/Table/Column.php
@@ -793,13 +793,9 @@ class Column
             }
 
             $method = 'set' . ucfirst($option);
-
-            if (ucfirst($option) == 'Limit') {
-                if ($value) {
-                    $value = (int)$value;
-                }
+            if ($method == 'setLimit') {
+                $value = (int)$value;
             }
-
             $this->$method($value);
         }
 


### PR DESCRIPTION
修复可能出现的 Phinx\\Db\\Table\\Column::setLimit(): Argument 1 ($limit) must be of type ?int, string given, called in \\vendor\\topthink\\think-migration\\phinx\\Db\\Table\\Column.php on line 796 问题