### PR TITLE
支持多数据库连接

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -46,7 +46,8 @@ abstract class Command extends \think\console\Command
      */
     protected function getDbConfig(): array
     {
-        $default = $this->app->config->get('database.default');
+        // 获取连接名称，默认为默认连接
+        $default = $this->input->getOption('connection') ?? $this->app->config->get('database.default');
 
         $config = $this->app->config->get("database.connections.{$default}");
 

--- a/src/command/migrate/Breakpoint.php
+++ b/src/command/migrate/Breakpoint.php
@@ -34,6 +34,7 @@ You cannot specify un-migrated targets
 <info>php think migrate:breakpoint -r</info>
 EOT
              );
+        $this->addOption('connection', 'c', InputOption::VALUE_REQUIRED, 'The database connection to use.');
     }
 
     protected function execute(Input $input, Output $output)

--- a/src/command/migrate/Create.php
+++ b/src/command/migrate/Create.php
@@ -14,6 +14,7 @@ use RuntimeException;
 use think\console\Command;
 use think\console\Input;
 use think\console\input\Argument as InputArgument;
+use think\console\input\Option as InputOption;
 use think\console\Output;
 use think\migration\Creator;
 
@@ -29,6 +30,7 @@ class Create extends Command
             ->setDescription('Create a new migration')
             ->addArgument('name', InputArgument::REQUIRED, 'What is the name of the migration?')
             ->setHelp(sprintf('%sCreates a new database migration%s', PHP_EOL, PHP_EOL));
+        $this->addOption('connection', 'c', InputOption::VALUE_REQUIRED, 'The database connection to use.');
     }
 
     /**

--- a/src/command/migrate/Rollback.php
+++ b/src/command/migrate/Rollback.php
@@ -37,6 +37,7 @@ The <info>migrate:rollback</info> command reverts the last migration, or optiona
 
 EOT
              );
+        $this->addOption('connection', 'c', InputOption::VALUE_REQUIRED, 'The database connection to use.');
     }
 
     /**

--- a/src/command/migrate/Run.php
+++ b/src/command/migrate/Run.php
@@ -36,6 +36,7 @@ The <info>migrate:run</info> command runs all available migrations, optionally u
 
 EOT
             );
+        $this->addOption('connection', 'c', InputOption::VALUE_REQUIRED, 'The database connection to use.');
     }
 
     /**

--- a/src/command/migrate/Status.php
+++ b/src/command/migrate/Status.php
@@ -31,6 +31,7 @@ The <info>migrate:status</info> command prints a list of all migrations, along w
 <info>php think migrate:status -f json</info>
 EOT
              );
+        $this->addOption('connection', 'c', InputOption::VALUE_REQUIRED, 'The database connection to use.');
     }
 
     /**

--- a/src/command/seed/Create.php
+++ b/src/command/seed/Create.php
@@ -12,6 +12,7 @@ namespace think\migration\command\seed;
 use Phinx\Util\Util;
 use think\console\Input;
 use think\console\input\Argument as InputArgument;
+use think\console\input\Option as InputOption;
 use think\console\Output;
 use think\migration\command\Seed;
 
@@ -26,6 +27,7 @@ class Create extends Seed
             ->setDescription('Create a new database seeder')
             ->addArgument('name', InputArgument::REQUIRED, 'What is the name of the seeder?')
             ->setHelp(sprintf('%sCreates a new database seeder%s', PHP_EOL, PHP_EOL));
+        $this->addOption('connection', 'c', InputOption::VALUE_REQUIRED, 'The database connection to use.');
     }
 
     /**

--- a/src/command/seed/Run.php
+++ b/src/command/seed/Run.php
@@ -34,6 +34,7 @@ class Run extends Seed
 
 EOT
              );
+        $this->addOption('connection', 'c', InputOption::VALUE_REQUIRED, 'The database connection to use.');
     }
 
     /**


### PR DESCRIPTION
增加对多个数据库连接的支持，使用示例
```
php think  migrate:run   --connection=local_sqlite -vvv
```